### PR TITLE
Renamed 'text' property to 'title' in 'Todo'-interface

### DIFF
--- a/app06-08/app/todos.ts
+++ b/app06-08/app/todos.ts
@@ -1,5 +1,5 @@
 export interface Todo {
-  text: string;
+  title: string;
   status: string;
 }
 export const TODOS =  [


### PR DESCRIPTION
'npm start' is doing its job without errors when changing the property name to 'title'.
